### PR TITLE
fix(ci): poll for the release source tag instead of racing the push retag

### DIFF
--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -151,7 +151,13 @@ jobs:
             # so we find the last commit that github processed before this one
             # which will have gone through the same retagging process
             # and use that sha as our key to find the Docker container related to that commit
-            old_tag=$(echo "${all_tags}" | grep "^sha-${{ env.BASE_SHA }}-.*\$") # .* is actual or retag
+            old_tag=$(echo "${all_tags}" | grep "^sha-${{ env.BASE_SHA }}-.*\$") || true # .* is actual or retag
+
+            if [ -z "${old_tag}" ]
+            then
+              echo "::error::No matching source tag found for base SHA ${{ env.BASE_SHA }}"
+              exit 1
+            fi
 
             echo "OLD_TAG=${old_tag}" >> "${GITHUB_ENV}"
             echo "SUFFIX=retag" >> "${GITHUB_ENV}"

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -90,11 +90,27 @@ jobs:
           repo="${{ github.repository }}"
           repo_lower="${repo,,}"
 
-          OLD_TAG=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
-            --paginate \
-            --jq '.[] | .metadata.container.tags[]' | grep "^sha-${{ github.sha }}-.*\$" | head --lines 1) # .* is actual or retag
+          # the source tag is pushed by the push-triggered retag workflow, which may still be running, so poll
+          OLD_TAG=""
 
-          if [ -z "${OLD_TAG}" ]; then
+          for attempt in $(seq 1 30)
+          do
+            # || true: no match yet, or a transient api error, both mean retry
+            OLD_TAG=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
+              --paginate \
+              --jq '.[] | .metadata.container.tags[]' | grep "^sha-${{ github.sha }}-.*\$" | head --lines 1) || true # .* is actual or retag
+
+            if [ -n "${OLD_TAG}" ]
+            then
+              break
+            fi
+
+            echo "No source tag for SHA ${{ github.sha }} yet (attempt ${attempt}/30), retrying in 30 seconds"
+            sleep 30
+          done
+
+          if [ -z "${OLD_TAG}" ]
+          then
             echo "::error::No matching source tag found for SHA ${{ github.sha }}"
             exit 1
           fi


### PR DESCRIPTION
The release event fires seconds after the release PR merges. The
`sha-<merge commit>` tag it needs is created by the push-triggered retag
workflow, which takes about 3 minutes to finish. The lookup only succeeded when
the release job starts late enough. Rerunning the workflow would solve
the problem but was annoying.

The failure was also silent. The step runs under set -e -o pipefail, so a grep
with no match fails the pipeline and exits the script before the emptiness
guard can print its error.

The fallback branch in the push retag workflow has the same pattern and gets
the same guard.
