### PR TITLE
fix(ci): skip Docker Hub tags that already exist with the expected digest

### DIFF
--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -93,24 +93,24 @@ jobs:
           # the source tag is pushed by the push-triggered retag workflow, which may still be running, so poll
           OLD_TAG=""
 
-          for attempt in $(seq 1 30)
-          do
+          for attempt in $(seq 1 30); do
+            if ((attempt > 1)); then
+              sleep 30
+            fi
+
+            echo "Looking for source tag sha-${{ github.sha }}-* (attempt ${attempt} of 30)"
+
             # || true: no match yet, or a transient api error, both mean retry
             OLD_TAG=$(gh api "/users/${{ github.repository_owner }}/packages/container/${repo_lower##*/}/versions" \
               --paginate \
               --jq '.[] | .metadata.container.tags[]' | grep "^sha-${{ github.sha }}-.*\$" | head --lines 1) || true # .* is actual or retag
 
-            if [ -n "${OLD_TAG}" ]
-            then
+            if [ -n "${OLD_TAG}" ]; then
               break
             fi
-
-            echo "No source tag for SHA ${{ github.sha }} yet (attempt ${attempt}/30), retrying in 30 seconds"
-            sleep 30
           done
 
-          if [ -z "${OLD_TAG}" ]
-          then
+          if [ -z "${OLD_TAG}" ]; then
             echo "::error::No matching source tag found for SHA ${{ github.sha }}"
             exit 1
           fi
@@ -164,6 +164,11 @@ jobs:
         run: |
           echo "${{ steps.meta-dockerhub.outputs.tags }}" | while IFS= read -r new_tag
             do
+              if [ "$(skopeo inspect --format '{{ .Digest }}' --no-tags "docker://${new_tag}" 2>/dev/null)" = "${{ steps.digest.outputs.digest }}" ]; then
+                echo "${new_tag} already exists, skipping"
+                continue
+              fi
+
               skopeo copy --all --preserve-digests --command-timeout 70s --retry-times 5 "docker://${FULL_IMAGE_NAME}:${OLD_TAG}" "docker://${new_tag}"
           done
 


### PR DESCRIPTION
Docker Hub's immutable tag rule (^v.*$) rejects any manifest push to an
existing version tag, even a byte-identical one. That broke re-runs of this
workflow after a partial failure. Comparing the destination digest first makes
re-runs skip already-published tags, while a tag that exists with a different
digest still fails the copy, which is a genuine conflict.

Also restyle the source tag poll to sleep before each attempt except the
first, matching the retry shape in ci.yml, so the loop no longer sleeps and
announces a retry after its final attempt.
