### PR TITLE
fix(ci): retry the PR number lookup when retagging the build cache

### DIFF
--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -118,7 +118,25 @@ jobs:
           pr_number=""
 
           if [ -n "${parent2}" ]; then
-            pr_number=$(gh api "/repos/${{ github.repository }}/commits/${parent2}/pulls" --jq '.[0].number')
+            pr_found=""
+
+            for attempt in $(seq 1 5); do
+              if ((attempt > 1)); then
+                sleep 5
+              fi
+
+              echo "Looking up the PR for ${parent2} (attempt ${attempt} of 5)"
+
+              if pr_number=$(gh api "/repos/${{ github.repository }}/commits/${parent2}/pulls" --jq '.[0].number'); then
+                pr_found=true
+                break
+              fi
+            done
+
+            if [ -z "${pr_found}" ]; then
+              echo "::error::PR lookup for ${parent2} failed after 5 attempts"
+              exit 1
+            fi
           fi
 
           if [ -z "${pr_number}" ]; then


### PR DESCRIPTION
gh api exits non-zero with "unexpected end of JSON input" when GitHub answers
with an empty body, which happens on transient 5xx responses. The skopeo calls
in this step already retry at both the skopeo and shell level, but the lookup
did not, so a single API blip failed the job.

Success is detected via gh's exit status rather than non-empty output because
an empty result is legitimate: a merge commit without an associated PR must
still fall through to the "No PR number found" skip instead of being retried
and failed.
