### PR TITLE
ci: compute version bump offline with git-cliff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,12 +132,12 @@ jobs:
         id: version
         run: |
           latest_tag=$(git describe --tags --abbrev=0 || true)
-          bumped=$(git-cliff --offline --bumped-version --unreleased)
+          bumped=$(git-cliff --bumped-version --unreleased --offline)
 
           # If git-cliff didn't bump (e.g. chore/ci only commits), force a patch increment
           # so we never tag a Docker image with the same version as the last release.
           if [ "${bumped}" = "${latest_tag}" ]; then
-            bumped=$(git-cliff --offline --bumped-version --bump patch --unreleased)
+            bumped=$(git-cliff --bumped-version --bump patch --unreleased --offline)
             echo "Force bumping to ${bumped}"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,13 +99,13 @@ jobs:
           fi
 
           bump_flag="auto"
-          bumped=$(git-cliff --offline --bumped-version --bump ${bump_flag} --unreleased)
+          bumped=$(git-cliff --bumped-version --bump ${bump_flag} --unreleased --offline)
 
           # If git-cliff didn't bump (e.g. chore/ci only commits), force a patch increment
           # so we never release the same version as the last tag.
           if [ "${bumped}" = "${latest_tag}" ]; then
             bump_flag="patch"
-            bumped=$(git-cliff --offline --bumped-version --bump patch --unreleased)
+            bumped=$(git-cliff --bumped-version --bump patch --unreleased --offline)
             echo "::notice::No conventional bump detected, forcing patch bump"
           fi
 


### PR DESCRIPTION
git-cliff's GitHub integration pages the entire commit history through `api.github.com` before computing the bumped version, so one transient connection error panics it and fails the job. The bump is derived purely from local commits and tags.
