### PR TITLE
ci(lint): enforce strict conventional commit subjects

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -30,12 +30,15 @@ jobs:
           show-progress: false
           fetch-depth: 0
 
-      - name: Disallow merge-style messages on non-merge commits
+      - name: Enforce strict conventional subjects
         shell: bash
         run: |
-          # cliff.toml exempts ^Merge messages from linting, ensure only real merge commits use that form
-          if git log --no-merges --format="%h %s" "origin/${GITHUB_BASE_REF}..HEAD" | grep "^[0-9a-f]* Merge"; then
-            echo "The commit(s) above are not merges, rewrite their messages to be conventional"
+          # Enforce '<type>(<scope>)!: <description>' subjects with lowercase type and scope.
+          # Also covers non-merge commits with merge-style messages, which cliff.toml's
+          # ^Merge skip would otherwise exempt from the git-cliff check below.
+          pattern='^[0-9a-f]+ [a-z]+(\([a-z0-9-]+\))?!?: .+$'
+          if git log --no-merges --format="%h %s" "origin/${GITHUB_BASE_REF}..HEAD" | grep --extended-regexp --invert-match "${pattern}"; then
+            echo "The commit(s) above do not match '<type>(<scope>)!: <description>' with a lowercase type and scope"
             exit 1
           fi
 


### PR DESCRIPTION
git-cliff's require_conventional is more permissive than this repo wants: it accepts uppercase types and uppercase scopes, and cliff.toml's ^Merge skip exempts merge-style subjects, so a non-merge commit whose subject starts with "Merge" passes unchecked.

Consequence: reverts need a `revert: ...` subject, `git revert`'s default `Revert "..."` no longer passes.
