### PR TITLE
ci(release): truncate bodies by characters instead of bytes

### DIFF
--- a/.github/workflows/graduate-release.yml
+++ b/.github/workflows/graduate-release.yml
@@ -108,7 +108,7 @@ jobs:
 
           if [ "$file_length" -gt "$max_length" ]; then
             truncated_length=$(( max_length - ${#truncation_message} ))
-            head --bytes="$truncated_length" release-notes.md > release-notes-truncated.md
+            TRUNC="$truncated_length" perl -CSD -0777 -pe '$_ = substr($_, 0, $ENV{TRUNC})' release-notes.md > release-notes-truncated.md
             printf '%s' "$truncation_message" >> release-notes-truncated.md
             mv release-notes-truncated.md release-notes.md
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
 
           if [ "$file_length" -gt "$max_length" ]; then
             truncated_length=$(( max_length - ${#truncation_message} ))
-            head --bytes="$truncated_length" diff-CHANGELOG.md > diff-CHANGELOG-truncated.md
+            TRUNC="$truncated_length" perl -CSD -0777 -pe '$_ = substr($_, 0, $ENV{TRUNC})' diff-CHANGELOG.md > diff-CHANGELOG-truncated.md
             printf '%s' "$truncation_message" >> diff-CHANGELOG-truncated.md
             mv diff-CHANGELOG-truncated.md diff-CHANGELOG.md
           fi

--- a/project-words.txt
+++ b/project-words.txt
@@ -42,6 +42,7 @@ telem
 tera
 topo
 trixie
+TRUNC
 uninlined
 unseparated
 usernamehw


### PR DESCRIPTION
`wc --chars` counts characters but `head --bytes` cuts bytes, so with multibyte UTF-8 in the changelog the cut can land mid-character.
`gh` JSON-encodes the dangling bytes as `U+FFFD`, which shows up as `�` in the published release or PR body. The byte cut also stops short of the limit, because every multibyte character spends 2 to 4 bytes of a budget that was counted in characters.
