### PR TITLE
chore: pass `--all-features` in `generate-test-report.sh`

### DIFF
--- a/generate-test-report.sh
+++ b/generate-test-report.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 base_rustflags=""
-cargo_features=""
+cargo_features="--all-features"
 
 export RUSTFLAGS="${base_rustflags} --allow=warnings -Cinstrument-coverage"
 


### PR DESCRIPTION
CI's coverage job passes `--all-features` via `CARGO_FEATURES`. The local script mirrors its build and nextest commands but left `cargo_features` empty, so feature-gated code went untested in local reports.
