### PR TITLE
chore(ci): consolidate coverage pipeline into `generate-test-report.sh`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,21 +131,14 @@ jobs:
 
       - name: Build with instrumentation support
         shell: bash
-        env:
-          RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -Cinstrument-coverage"
-          # build-* ones are not parsed by grcov
-          LLVM_PROFILE_FILE: "profiling/build-%p-%m.profraw"
         run: |
-          cargo build ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace
+          ./generate-test-report.sh build
 
       - name: Run nextest
         shell: bash
         id: tests
-        env:
-          RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -Cinstrument-coverage"
-          LLVM_PROFILE_FILE: "profiling/profile-%p-%m.profraw"
         run: |
-          cargo nextest run --profile ci --no-fail-fast ${{ env.CARGO_FEATURES }} --all-targets --workspace
+          ./generate-test-report.sh test
         continue-on-error: true
 
       - name: Upload test results
@@ -158,22 +151,10 @@ jobs:
 
       - name: Run grcov
         shell: bash
+        env:
+          GRCOV_OUTPUT_TYPES: lcov
         run: |
-          mapfile -t profraw_files < <(find . -name "profile-*.profraw" -print)
-
-          grcov "${profraw_files[@]}" \
-            --binary-path ./target/debug/ \
-            --branch \
-            --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!)" \
-            --excl-br-start "mod tests \{" \
-            --excl-line "(#\\[derive\\()|(^\s*.await[;,]?$)" \
-            --excl-start "mod tests \{" \
-            --ignore-not-existing \
-            --keep-only "crates/**" \
-            --llvm \
-            --output-path ./reports/ \
-            --output-type lcov \
-            --source-dir .
+          ./generate-test-report.sh report
 
       - name: Record Rust version
         shell: bash

--- a/generate-test-report.sh
+++ b/generate-test-report.sh
@@ -1,31 +1,67 @@
 #!/bin/bash
 
-base_rustflags=""
-cargo_features="--all-features"
+set -eu -o pipefail
 
-export RUSTFLAGS="${base_rustflags} --allow=warnings -Cinstrument-coverage"
+cargo_features="${CARGO_FEATURES:---all-features}"
+grcov_output_types="${GRCOV_OUTPUT_TYPES:-lcov,html,markdown}"
 
-# build-* ones are not parsed by grcov
-export LLVM_PROFILE_FILE="profiling/build-%p-%m.profraw"
-cargo build ${cargo_features} --all-targets --locked --workspace
+export RUSTFLAGS="--allow=warnings -Cinstrument-coverage"
 
-# cleanup old values
-find -name '*.profraw' | xargs rm
+build() {
+    # build-* ones are not parsed by grcov
+    LLVM_PROFILE_FILE="profiling/build-%p-%m.profraw" \
+        cargo build ${cargo_features} --all-targets --locked --workspace
+}
 
-# different from the `cargo build` ones
-LLVM_PROFILE_FILE="profiling/profile-%p-%m.profraw"
-cargo nextest run --profile ci --no-fail-fast ${cargo_features} --all-targets --workspace
+run_tests() {
+    # cleanup old values
+    find . -name '*.profraw' -print0 | xargs --null --no-run-if-empty rm
 
-grcov $(find . -name "profile-*.profraw" -print) \
-    --binary-path ./target/debug/ \
-    --branch \
-    --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!)" \
-    --excl-br-start "mod tests \{" \
-    --excl-line "(#\\[derive\\()|(^\s*.await[;,]?$)" \
-    --excl-start "mod tests \{" \
-    --ignore-not-existing \
-    --keep-only "crates/**" \
-    --llvm \
-    --output-path ./reports/ \
-    --output-type lcov,html,markdown \
-    --source-dir .
+    # different from the `cargo build` ones
+    LLVM_PROFILE_FILE="profiling/profile-%p-%m.profraw" \
+        cargo nextest run --profile ci --no-fail-fast ${cargo_features} --all-targets --workspace
+}
+
+report() {
+    mapfile -t profraw_files < <(find . -name "profile-*.profraw" -print)
+
+    grcov "${profraw_files[@]}" \
+        --binary-path ./target/debug/ \
+        --branch \
+        --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!)" \
+        --excl-br-start "mod tests \{" \
+        --excl-line "(#\\[derive\\()|(^\s*.await[;,]?$)" \
+        --excl-start "mod tests \{" \
+        --ignore-not-existing \
+        --keep-only "crates/**" \
+        --llvm \
+        --output-path ./reports/ \
+        --output-type "${grcov_output_types}" \
+        --source-dir .
+}
+
+case "${1:-all}" in
+    build)
+        build
+        ;;
+    test)
+        run_tests
+        ;;
+    report)
+        report
+        ;;
+    all)
+        build
+
+        test_exit_code=0
+        run_tests || test_exit_code=$?
+
+        report
+
+        exit "${test_exit_code}"
+        ;;
+    *)
+        echo "usage: $0 [build|test|report]" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
The `cargo-test-and-report` job and the local script duplicated the coverage `RUSTFLAGS`, the `LLVM_PROFILE_FILE` conventions, and the nine-flag grcov invocation, and they drifted (local runs silently missed `--all-features`). CI now calls the script's `build`/`test`/`report` phases as separate steps, keeping build failures fatal before uploads and test failures flowing through `steps.tests.outcome`. `base_rustflags` and the `env.RUSTFLAGS` interpolation are dropped, `--deny=warnings --allow=warnings` already reduced to the plain `--allow=warnings` the script sets.